### PR TITLE
fix: Username for custom mushroom

### DIFF
--- a/src/main/java/fungeye/cloud/controllers/MushroomController.java
+++ b/src/main/java/fungeye/cloud/controllers/MushroomController.java
@@ -1,5 +1,6 @@
 package fungeye.cloud.controllers;
 
+import fungeye.cloud.domain.dtos.CustomMushroomCreationDto;
 import fungeye.cloud.domain.dtos.DefaultMushroomCreationDto;
 import fungeye.cloud.domain.dtos.MushroomCreationDTO;
 import fungeye.cloud.domain.dtos.MushroomDto;
@@ -39,6 +40,15 @@ public class MushroomController {
             @RequestBody MushroomCreationDTO dto) {
         // They do the same thing, but this one isn't admin protected
         MushroomDto saved = service.createMushroom(dto);
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
+    }
+
+    // New endpoint using the username instead and with conditions
+    @PostMapping("/mushroom/custom/conditions")
+    public ResponseEntity<MushroomDto> createCustomMushroomWithConditions(
+            @RequestBody CustomMushroomCreationDto dto) {
+        // They do the same thing, but this one isn't admin protected
+        MushroomDto saved = service.createCustomMushroom(dto);
         return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 

--- a/src/main/java/fungeye/cloud/domain/dtos/CustomMushroomCreationDto.java
+++ b/src/main/java/fungeye/cloud/domain/dtos/CustomMushroomCreationDto.java
@@ -1,0 +1,14 @@
+package fungeye.cloud.domain.dtos;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CustomMushroomCreationDto {
+    private String name;
+    private String description;
+    private String origin;
+    private List<IdealConditionCreationDto> idealConditionCreationDtos;
+    private String username;
+}

--- a/src/main/java/fungeye/cloud/service/MushroomService.java
+++ b/src/main/java/fungeye/cloud/service/MushroomService.java
@@ -57,6 +57,26 @@ public class MushroomService {
         return MushroomMapper.mapToMushroomDto(saved);
     }
 
+    public MushroomDto createCustomMushroom(CustomMushroomCreationDto dto) {
+        Mushroom toSave = MushroomMapper.mapCustomCreateToMushroom(dto);
+        Optional<UserEntity> user = userRepository.findByUsername(dto.getUsername());
+        user.ifPresent(toSave::setUser);
+        Mushroom saved = repository.save(toSave);
+        Long mushroomId = saved.getId();
+        List<IdealConditionCreationDto> conditionCreationDtos = dto.getIdealConditionCreationDtos();
+        if (conditionCreationDtos != null && !conditionCreationDtos.isEmpty()) {
+            for (IdealConditionCreationDto idealDto :
+                    conditionCreationDtos) {
+                IdealCondition conditionToSave = IdealConditionsMapper.mapCreateToIdealCondition(idealDto);
+                IdealConditionId id = conditionToSave.getId();
+                id.setMushroomId(mushroomId);
+                conditionToSave.setId(id);
+                idealConditionRepository.save(conditionToSave);
+            }
+        }
+        return MushroomMapper.mapToMushroomDto(saved);
+    }
+
     public MushroomDto getByMushroomId(Long id) {
         Optional<Mushroom> mushroom = repository.findById(id);
         if (mushroom.isPresent()) {

--- a/src/main/java/fungeye/cloud/service/mappers/MushroomMapper.java
+++ b/src/main/java/fungeye/cloud/service/mappers/MushroomMapper.java
@@ -1,5 +1,6 @@
 package fungeye.cloud.service.mappers;
 
+import fungeye.cloud.domain.dtos.CustomMushroomCreationDto;
 import fungeye.cloud.domain.dtos.DefaultMushroomCreationDto;
 import fungeye.cloud.domain.dtos.MushroomCreationDTO;
 import fungeye.cloud.domain.dtos.MushroomDto;
@@ -51,6 +52,21 @@ public class MushroomMapper {
         UserEntity user = new UserEntity();
         // Set to three for the admin
         user.setId(3);
+        mushroom.setUser(user);
+
+        return mushroom;
+    }
+
+    public static Mushroom mapCustomCreateToMushroom(CustomMushroomCreationDto dto) {
+        Mushroom mushroom = new Mushroom();
+        mushroom.setName(dto.getName());
+        mushroom.setDescription(dto.getDescription());
+        mushroom.setOrigin(dto.getOrigin());
+
+        // Create a user with only an id
+        UserEntity user = new UserEntity();
+        // Set to three for the admin
+        user.setUsername(dto.getUsername());
         mushroom.setUser(user);
 
         return mushroom;

--- a/src/test/java/fungeye/cloud/controllers/MushroomControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/MushroomControllerTest.java
@@ -1,9 +1,6 @@
 package fungeye.cloud.controllers;
 
-import fungeye.cloud.domain.dtos.DefaultMushroomCreationDto;
-import fungeye.cloud.domain.dtos.IdealConditionDto;
-import fungeye.cloud.domain.dtos.MushroomCreationDTO;
-import fungeye.cloud.domain.dtos.MushroomDto;
+import fungeye.cloud.domain.dtos.*;
 import fungeye.cloud.domain.enities.Mushroom;
 import fungeye.cloud.domain.enities.users.UserEntity;
 import fungeye.cloud.service.MushroomService;
@@ -14,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +55,53 @@ class MushroomControllerTest {
         assertEquals(HttpStatus.CREATED, response2.getStatusCode());
         assertEquals(mushroomDto, response1.getBody());
         assertEquals(mushroomDto, response2.getBody());
+    }
+
+    @Test
+    void createDefaultMushroom_shouldCreateAndReturnMushroomDto() {
+        DefaultMushroomCreationDto mushroomCreationDTO = new DefaultMushroomCreationDto();
+        mushroomCreationDTO.setName("Portobello");
+        mushroomCreationDTO.setDescription("Large mushroom with a meaty texture.");
+
+        MushroomDto mushroomDto = new MushroomDto();
+        mushroomDto.setId(1L);
+        mushroomDto.setName("Portobello");
+        mushroomDto.setDescription("Large mushroom with a meaty texture.");
+        mushroomDto.setUserId(3);
+
+        when(service.createDefaultMushroom(mushroomCreationDTO)).thenReturn(mushroomDto);
+
+        ResponseEntity<MushroomDto> response1 = controller.createDefaultMushroom(mushroomCreationDTO);
+
+        verify(service, times(1)).createDefaultMushroom(mushroomCreationDTO);
+        assertEquals(HttpStatus.CREATED, response1.getStatusCode());
+        assertEquals(mushroomDto, response1.getBody());
+    }
+
+    @Test
+    void createCustomMushroom_shouldCreateAndReturnMushroomDto() {
+        CustomMushroomCreationDto mushroomCreationDTO = new CustomMushroomCreationDto();
+        mushroomCreationDTO.setName("Portobello");
+        mushroomCreationDTO.setDescription("Large mushroom with a meaty texture.");
+        mushroomCreationDTO.setUsername("john");
+
+        MushroomDto mushroomDto = new MushroomDto();
+        mushroomDto.setId(1L);
+        mushroomDto.setName("Portobello");
+        mushroomDto.setDescription("Large mushroom with a meaty texture.");
+        mushroomDto.setUserId(2);
+
+        UserEntity user = new UserEntity();
+        user.setId(2);
+        user.setUsername("john");
+
+        when(service.createCustomMushroom(mushroomCreationDTO)).thenReturn(mushroomDto);
+
+        ResponseEntity<MushroomDto> response1 = controller.createCustomMushroomWithConditions(mushroomCreationDTO);
+
+        verify(service, times(1)).createCustomMushroom(mushroomCreationDTO);
+        assertEquals(HttpStatus.CREATED, response1.getStatusCode());
+        assertEquals(mushroomDto, response1.getBody());
     }
 
     @Test

--- a/src/test/java/fungeye/cloud/service/MushroomServiceTest.java
+++ b/src/test/java/fungeye/cloud/service/MushroomServiceTest.java
@@ -1,5 +1,6 @@
 package fungeye.cloud.service;
 
+import fungeye.cloud.domain.dtos.CustomMushroomCreationDto;
 import fungeye.cloud.domain.dtos.DefaultMushroomCreationDto;
 import fungeye.cloud.domain.dtos.MushroomCreationDTO;
 import fungeye.cloud.domain.dtos.MushroomDto;
@@ -85,6 +86,34 @@ class MushroomServiceTest {
         when(userRepository.findById(1)).thenReturn(Optional.of(user));
 
         MushroomDto actual = service.createDefaultMushroom(defaultMushroom);
+
+        assertEquals(expected, actual);
+
+        verify(repository, times(1)).save(any());
+    }
+
+    @Test
+    void testCustomCreateMushroom() {
+        CustomMushroomCreationDto customMushroom = new CustomMushroomCreationDto();
+        customMushroom.setName("Mushroom");
+        customMushroom.setDescription("Test mushroom");
+        customMushroom.setOrigin("Denmark");
+        customMushroom.setUsername("john");
+
+        Mushroom saved = MushroomMapper.mapCustomCreateToMushroom(customMushroom);
+        saved.setId(1L);
+
+        UserEntity user = new UserEntity();
+        user.setId(1);
+        user.setUsername("john");
+        saved.setUser(user);
+
+        MushroomDto expected = MushroomMapper.mapToMushroomDto(saved);
+
+        when(repository.save(any())).thenReturn(saved);
+        when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+
+        MushroomDto actual = service.createCustomMushroom(customMushroom);
 
         assertEquals(expected, actual);
 

--- a/src/test/java/fungeye/cloud/service/mappers/MushroomMapperTest.java
+++ b/src/test/java/fungeye/cloud/service/mappers/MushroomMapperTest.java
@@ -1,5 +1,6 @@
 package fungeye.cloud.service.mappers;
 
+import fungeye.cloud.domain.dtos.CustomMushroomCreationDto;
 import fungeye.cloud.domain.dtos.DefaultMushroomCreationDto;
 import fungeye.cloud.domain.dtos.MushroomCreationDTO;
 import fungeye.cloud.domain.dtos.MushroomDto;
@@ -104,6 +105,18 @@ class MushroomMapperTest {
         dto.setDescription("A common mushroom");
 
         Mushroom mushroom = MushroomMapper.mapDefaultCreateToMushroom(dto);
+
+        assertEquals(dto.getName(), mushroom.getName());
+        assertEquals(dto.getDescription(), mushroom.getDescription());
+    }
+
+    @Test
+    void testMapCustomCreateToMushroom() {
+        CustomMushroomCreationDto dto = new CustomMushroomCreationDto();
+        dto.setName("Button Mushroom");
+        dto.setDescription("A common mushroom");
+
+        Mushroom mushroom = MushroomMapper.mapCustomCreateToMushroom(dto);
 
         assertEquals(dto.getName(), mushroom.getName());
         assertEquals(dto.getDescription(), mushroom.getDescription());


### PR DESCRIPTION
TG-176: Adds a new endpoint that takes a username for the custom mushroom instead of the userId