### PR TITLE
Update SecurityConfig.java

### DIFF
--- a/src/main/java/fungeye/cloud/security/SecurityConfig.java
+++ b/src/main/java/fungeye/cloud/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors().and()
                 .csrf().disable()
                 .exceptionHandling()
                 .authenticationEntryPoint(authEntryPoint)


### PR DESCRIPTION
Should fix cors problems in front end.
When using Spring Security as we are, CORS needs to be enabled in the filterchain as well, as the requests hits this one before the actual endpoint