### PR TITLE
hotfix: Changing http status found to ok

### DIFF
--- a/src/main/java/fungeye/cloud/controllers/BoxController.java
+++ b/src/main/java/fungeye/cloud/controllers/BoxController.java
@@ -39,7 +39,7 @@ public class BoxController {
 
     @GetMapping(value = "/{username}/boxes/empty")
     ResponseEntity<List<BoxDto>> getAllEmptyBoxesByUserName(@PathVariable String username) {
-        return new ResponseEntity<>(service.getAllEmptyByUserName(username), HttpStatus.FOUND);
+        return new ResponseEntity<>(service.getAllEmptyByUserName(username), HttpStatus.OK);
     }
 
     @GetMapping(value = "/{username}/boxes")

--- a/src/main/java/fungeye/cloud/controllers/HarvestController.java
+++ b/src/main/java/fungeye/cloud/controllers/HarvestController.java
@@ -30,13 +30,13 @@ public class HarvestController {
     @GetMapping("/{username}")
     public ResponseEntity<List<HarvestDetailsDto>> getAllHarvestsByUsername(@PathVariable(name = "username") String username) {
 
-        return new ResponseEntity<>(service.getAllHarvestsByUsername(username), HttpStatus.FOUND);
+        return new ResponseEntity<>(service.getAllHarvestsByUsername(username), HttpStatus.OK);
     }
 
     @GetMapping("/grows/{growId}")
     public ResponseEntity<List<HarvestDetailsDto>> getAllHarvestsByGrowId(@PathVariable(name = "growId") Long growId) {
 
-        return new ResponseEntity<>(service.getAllHarvestsByGrowId(growId), HttpStatus.FOUND);
+        return new ResponseEntity<>(service.getAllHarvestsByGrowId(growId), HttpStatus.OK);
     }
 
 

--- a/src/main/java/fungeye/cloud/controllers/IdealConditionsController.java
+++ b/src/main/java/fungeye/cloud/controllers/IdealConditionsController.java
@@ -29,6 +29,6 @@ public class IdealConditionsController {
     public ResponseEntity<List<IdealConditionDto>> getIdealConditionsByMushroomId(@PathVariable Long mushroomId)
     {
         List<IdealConditionDto> found = service.getByMushroomId(mushroomId);
-        return new ResponseEntity<>(found, HttpStatus.FOUND);
+        return new ResponseEntity<>(found, HttpStatus.OK);
     }
 }

--- a/src/main/java/fungeye/cloud/controllers/MushroomController.java
+++ b/src/main/java/fungeye/cloud/controllers/MushroomController.java
@@ -55,13 +55,13 @@ public class MushroomController {
     @GetMapping(value = "/mushroom/{id}")
     public ResponseEntity<MushroomDto> getMushroomById(@PathVariable Long id) {
         MushroomDto found = service.getByMushroomId(id);
-        return new ResponseEntity<>(found, HttpStatus.FOUND);
+        return new ResponseEntity<>(found, HttpStatus.OK);
     }
 
     @GetMapping(value = "/mushroom")
     public ResponseEntity<List<MushroomDto>> getAllDefaultMushrooms() {
         List<MushroomDto> all = service.getAllDefault();
-        return new ResponseEntity<>(all, HttpStatus.FOUND);
+        return new ResponseEntity<>(all, HttpStatus.OK);
     }
 
     @GetMapping(value = "/mushroom/custom/{username}")
@@ -69,7 +69,7 @@ public class MushroomController {
         List<MushroomDto> allDefault = service.getAllDefault();
         List<MushroomDto> custom = service.getCustom(username);
         custom.addAll(allDefault);
-        return new ResponseEntity<>(custom, HttpStatus.FOUND);
+        return new ResponseEntity<>(custom, HttpStatus.OK);
     }
 
     @PatchMapping(value = "/mushroom/{id}")

--- a/src/test/java/fungeye/cloud/controllers/BoxControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/BoxControllerTest.java
@@ -101,7 +101,7 @@ class BoxControllerTest {
 
         ResponseEntity<List<BoxDto>> responseEntity = boxController.getAllEmptyBoxesByUserName(userName);
 
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(dtos, responseEntity.getBody());
         verify(boxService, times(1)).getAllEmptyByUserName(userName);
     }

--- a/src/test/java/fungeye/cloud/controllers/HarvestControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/HarvestControllerTest.java
@@ -49,7 +49,7 @@ class HarvestControllerTest {
 
         ResponseEntity<List<HarvestDetailsDto>> responseEntity = controller.getAllHarvestsByUsername(username);
 
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(expectedOutput, responseEntity.getBody());
         verify(service, times(1)).getAllHarvestsByUsername(username);
     }
@@ -72,7 +72,7 @@ class HarvestControllerTest {
 
         ResponseEntity<List<HarvestDetailsDto>> responseEntity = controller.getAllHarvestsByUsername(username);
 
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(expectedOutput, responseEntity.getBody());
         verify(service, times(1)).getAllHarvestsByUsername(username);
     }
@@ -95,7 +95,7 @@ class HarvestControllerTest {
 
         ResponseEntity<List<HarvestDetailsDto>> responseEntity = controller.getAllHarvestsByGrowId(1L);
 
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(expectedOutput, responseEntity.getBody());
         verify(service, times(1)).getAllHarvestsByGrowId(1L);
     }

--- a/src/test/java/fungeye/cloud/controllers/IdealConditionsControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/IdealConditionsControllerTest.java
@@ -56,7 +56,7 @@ class IdealConditionsControllerTest {
         ResponseEntity<List<IdealConditionDto>> responseEntity = controller.getIdealConditionsByMushroomId(mushroomId);
 
         // then
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(expectedOutput, responseEntity.getBody());
         verify(service, times(1)).getByMushroomId(mushroomId);
     }

--- a/src/test/java/fungeye/cloud/controllers/MushroomControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/MushroomControllerTest.java
@@ -231,7 +231,7 @@ class MushroomControllerTest {
         ResponseEntity<MushroomDto> response = controller.getMushroomById(mushroomId);
 
         verify(service, times(1)).getByMushroomId(mushroomId);
-        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mushroomDto, response.getBody());
     }
 
@@ -255,7 +255,7 @@ class MushroomControllerTest {
         ResponseEntity<List<MushroomDto>> response = controller.getAllDefaultMushrooms();
 
         verify(service, times(1)).getAllDefault();
-        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mushroomDtos, response.getBody());
     }
 
@@ -306,7 +306,7 @@ class MushroomControllerTest {
         ResponseEntity<List<MushroomDto>> response = controller.getDefaultAndCustom("john");
 
         assertEquals(expected, response.getBody());
-        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
 
         verify(service, times(1)).getCustom("john");
         verify(service, times(1)).getAllDefault();


### PR DESCRIPTION
The found http status is not for when things are found, which was causing errors for the frontend. This fix works to bypass this by changing these occurrences.