### PR TITLE
Fix/grow stage showing twice

### DIFF
--- a/src/main/java/fungeye/cloud/domain/dtos/grow/GrowCreationDto.java
+++ b/src/main/java/fungeye/cloud/domain/dtos/grow/GrowCreationDto.java
@@ -12,7 +12,7 @@ public class GrowCreationDto {
     private SimpleDateDto date;
     private String developStage;
 
-    public void setDevelopmentStage(String developStage) {
+    public void setDevelopStage(String developStage) {
         if (developStage.equals("spawn run") ||
                 developStage.equals("pinning") ||
                 developStage.equals("fruiting")) {

--- a/src/main/java/fungeye/cloud/domain/dtos/grow/GrowDto.java
+++ b/src/main/java/fungeye/cloud/domain/dtos/grow/GrowDto.java
@@ -24,4 +24,15 @@ public class GrowDto {
 
     public GrowDto() {
     }
+
+    public void setStage(String stage) {
+        if (stage.equals("spawn run") ||
+                stage.equals("pinning") ||
+                stage.equals("fruiting")) {
+            this.stage = stage;
+        }
+        else {
+            throw new IllegalArgumentException("Not a valid development stage");
+        }
+    }
 }

--- a/src/main/java/fungeye/cloud/domain/dtos/grow/GrowUpdateDto.java
+++ b/src/main/java/fungeye/cloud/domain/dtos/grow/GrowUpdateDto.java
@@ -8,7 +8,7 @@ public class GrowUpdateDto {
     private String developStage;
     private Boolean isActive;
 
-    public void setDevelopmentStage(String developStage) {
+    public void setDevelopStage(String developStage) {
         if (developStage.equals("spawn run") ||
                 developStage.equals("pinning") ||
                 developStage.equals("fruiting")) {

--- a/src/test/java/fungeye/cloud/controllers/GrowControllerTest.java
+++ b/src/test/java/fungeye/cloud/controllers/GrowControllerTest.java
@@ -50,7 +50,7 @@ class GrowControllerTest {
         dto.setBoxId(1L);
         dto.setMushroomId(1L);
         dto.setUsername("john");
-        dto.setDevelopStage("Spawn run");
+        dto.setDevelopStage("spawn run");
 
         SimpleDateDto dateDto = new SimpleDateDto(2023, 5, 5);
         dto.setDate(dateDto);
@@ -81,7 +81,7 @@ class GrowControllerTest {
         GrowDto dto1 = new GrowDto();
         dto1.setBoxId(1L);
         dto1.setMushroomId(1L);
-        dto1.setStage("Spawn run");
+        dto1.setStage("spawn run");
         dto1.setActive(true);
 
         DateTimeDto dateTimeDto = DateTimeMapper.mapToDateDto(LocalDate.now());
@@ -90,7 +90,7 @@ class GrowControllerTest {
         GrowDto dto2 = new GrowDto();
         dto2.setBoxId(2L);
         dto2.setMushroomId(2L);
-        dto2.setStage("Spawn run");
+        dto2.setStage("spawn run");
         dto2.setActive(true);
         dto2.setDate(dateTimeDto);
 
@@ -131,7 +131,7 @@ class GrowControllerTest {
         Grow initial = new Grow();
         initial.setId(1L);
         initial.setIsActive(true);
-        initial.setDevelopmentStage("Fruiting");
+        initial.setDevelopmentStage("fruiting");
         initial.setDateStarted(LocalDate.of(2023, 5, 5));
 
         Mushroom mushroom = new Mushroom();
@@ -145,11 +145,11 @@ class GrowControllerTest {
         GrowUpdateDto update = new GrowUpdateDto();
         update.setId(1L);
         update.setIsActive(false);
-        update.setDevelopStage("Fruiting");
+        update.setDevelopStage("fruiting");
 
         GrowDto dto = GrowMapper.mapToGrowDto(initial);
         dto.setActive(false);
-        dto.setStage("Fruiting");
+        dto.setStage("fruiting");
 
         Mockito.when(service.updateGrow(update)).thenReturn(dto);
 
@@ -165,7 +165,7 @@ class GrowControllerTest {
         Grow grow = new Grow();
         grow.setId(1L);
         grow.setIsActive(true);
-        grow.setDevelopmentStage("Fruiting");
+        grow.setDevelopmentStage("fruiting");
         grow.setDateStarted(LocalDate.of(2023, 5, 5));
 
         Mushroom mushroom = new Mushroom();

--- a/src/test/java/fungeye/cloud/domain/dtos/GrowCreationDtoTest.java
+++ b/src/test/java/fungeye/cloud/domain/dtos/GrowCreationDtoTest.java
@@ -21,8 +21,8 @@ public class GrowCreationDtoTest {
     @Test
     void testValidDevelopmentStage() {
         growCreationDto.setDevelopStage("spawn run");
-        growCreationDto.setDevelopmentStage("pinning");
-        growCreationDto.setDevelopmentStage("fruiting");
+        growCreationDto.setDevelopStage("pinning");
+        growCreationDto.setDevelopStage("fruiting");
 
         assertEquals("fruiting", growCreationDto.getDevelopStage());
     }
@@ -30,7 +30,7 @@ public class GrowCreationDtoTest {
     @Test
     void testInvalidDevelopmentStage() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            growCreationDto.setDevelopmentStage("It's not a phase! I'll be a spore forever");
+            growCreationDto.setDevelopStage("It's not a phase! I'll be a spore forever");
         });
 
         assertEquals("Not a valid development stage", exception.getMessage());

--- a/src/test/java/fungeye/cloud/domain/dtos/GrowDtoTest.java
+++ b/src/test/java/fungeye/cloud/domain/dtos/GrowDtoTest.java
@@ -18,7 +18,7 @@ class GrowDtoTest {
         // Arrange
         Long id = 1L;
         DateTimeDto date = new DateTimeDto(2023, 4, 14, 10, 30, 0);
-        String stage = "Growing";
+        String stage = "spawn run";
         boolean active = true;
         Long boxId = 2L;
         List<MushroomDto> mushroomDtoList = new ArrayList<>();

--- a/src/test/java/fungeye/cloud/domain/dtos/GrowUpdateDtoTest.java
+++ b/src/test/java/fungeye/cloud/domain/dtos/GrowUpdateDtoTest.java
@@ -17,8 +17,8 @@ class GrowUpdateDtoTest {
     @Test
     void testValidDevelopmentStage() {
         growUpdateDto.setDevelopStage("spawn run");
-        growUpdateDto.setDevelopmentStage("pinning");
-        growUpdateDto.setDevelopmentStage("fruiting");
+        growUpdateDto.setDevelopStage("pinning");
+        growUpdateDto.setDevelopStage("fruiting");
 
         assertEquals("fruiting", growUpdateDto.getDevelopStage());
     }
@@ -26,7 +26,7 @@ class GrowUpdateDtoTest {
     @Test
     void testInvalidDevelopmentStage() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            growUpdateDto.setDevelopmentStage("It's not a phase! I'll be a spore forever");
+            growUpdateDto.setDevelopStage("It's not a phase! I'll be a spore forever");
         });
 
         assertEquals("Not a valid development stage", exception.getMessage());

--- a/src/test/java/fungeye/cloud/service/GrowServiceTest.java
+++ b/src/test/java/fungeye/cloud/service/GrowServiceTest.java
@@ -42,7 +42,7 @@ class GrowServiceTest {
         dto.setBoxId(1L);
         dto.setMushroomId(1L);
         dto.setUsername("john");
-        dto.setDevelopStage("Spawn run");
+        dto.setDevelopStage("spawn run");
 
         SimpleDateDto dateDto = new SimpleDateDto(2023, 5, 5);
         dto.setDate(dateDto);
@@ -133,7 +133,7 @@ class GrowServiceTest {
         GrowUpdateDto update = new GrowUpdateDto();
         update.setId(1L);
         update.setIsActive(false);
-        update.setDevelopStage("Fruiting");
+        update.setDevelopStage("fruiting");
 
         Mockito.when(repository.findById(1L)).thenReturn(Optional.of(initial));
 
@@ -156,7 +156,7 @@ class GrowServiceTest {
         Grow grow = new Grow();
         grow.setId(1L);
         grow.setIsActive(true);
-        grow.setDevelopmentStage("Fruiting");
+        grow.setDevelopmentStage("fruiting");
         grow.setDateStarted(LocalDate.of(2023, 5, 5));
         grow.setBox(box);
         grow.setMushroom(mushroom);

--- a/src/test/java/fungeye/cloud/service/mappers/BoxMapperTest.java
+++ b/src/test/java/fungeye/cloud/service/mappers/BoxMapperTest.java
@@ -52,6 +52,7 @@ class BoxMapperTest {
         grow.setBox(box);
         grow.setDateStarted(mockDate);
         grow.setIsActive(true);
+        grow.setDevelopmentStage("fruiting");
 
         Mushroom mushroom = new Mushroom();
         mushroom.setId(1L);
@@ -118,33 +119,39 @@ class BoxMapperTest {
         grow1.setDateStarted(mockDate);
         grow1.setIsActive(false);
         grow1.setMushroom(mushroom1);
+        grow1.setDevelopmentStage("fruiting");
         Grow grow2 = new Grow();
         grow2.setBox(box1);
         grow2.setDateStarted(mockDate.plusDays(20));
         grow2.setIsActive(true);
         grow2.setMushroom(mushroom2);
+        grow2.setDevelopmentStage("fruiting");
 
         Grow grow3 = new Grow();
         grow3.setBox(box2);
         grow3.setDateStarted(mockDate);
         grow3.setIsActive(false);
         grow3.setMushroom(mushroom3);
+        grow3.setDevelopmentStage("fruiting");
         Grow grow4 = new Grow();
         grow4.setBox(box2);
         grow4.setDateStarted(mockDate.plusDays(20));
         grow4.setIsActive(true);
         grow4.setMushroom(mushroom4);
+        grow4.setDevelopmentStage("fruiting");
 
         Grow grow5 = new Grow();
         grow5.setBox(box3);
         grow5.setDateStarted(mockDate);
         grow5.setIsActive(false);
         grow5.setMushroom(mushroom3);
+        grow5.setDevelopmentStage("fruiting");
         Grow grow6 = new Grow();
         grow6.setBox(box3);
         grow6.setDateStarted(mockDate.plusDays(20));
         grow6.setIsActive(true);
         grow6.setMushroom(mushroom1);
+        grow6.setDevelopmentStage("fruiting");
 
 
         Set<Grow> grows1 = new HashSet<>();

--- a/src/test/java/fungeye/cloud/service/mappers/GrowMapperTest.java
+++ b/src/test/java/fungeye/cloud/service/mappers/GrowMapperTest.java
@@ -40,7 +40,7 @@ class GrowMapperTest {
         grow.setBox(box);
         grow.setIsActive(true);
         grow.setDateStarted(dateStarted);
-        grow.setDevelopmentStage("Early");
+        grow.setDevelopmentStage("spawn run");
         grow.setMushroom(shroom1);
 
 
@@ -79,7 +79,7 @@ class GrowMapperTest {
         grow1.setBox(box1);
         grow1.setIsActive(true);
         grow1.setDateStarted(dateStarted);
-        grow1.setDevelopmentStage("Early");
+        grow1.setDevelopmentStage("spawn run");
         grow1.setMushroom(shroom1);
 
         Grow grow2 = new Grow();
@@ -87,7 +87,7 @@ class GrowMapperTest {
         grow2.setBox(box1);
         grow2.setIsActive(true);
         grow2.setDateStarted(dateStarted);
-        grow2.setDevelopmentStage("Early");
+        grow2.setDevelopmentStage("spawn run");
         grow2.setMushroom(shroom2);
 
         Set<Grow> grows = new HashSet<>();


### PR DESCRIPTION
Fixed method names that were causing duplicates in the development stage for the dtos on the endpoints. Also added the development stage requirements to the grow dto and fixed related tests