### PR TITLE
hotfix: Use the right method to duplicate

### DIFF
--- a/src/main/java/fungeye/cloud/websockets/HardwareTutorial.java
+++ b/src/main/java/fungeye/cloud/websockets/HardwareTutorial.java
@@ -189,7 +189,7 @@ public class HardwareTutorial implements WebSocket.Listener {
             condDto.setLight((double) light);
             // measurementService.addMeasuredCondition(condDto);
             // Using the below method to send a copy of the measurement to all active boxes
-            measurementService.addMeasuredCondition(condDto);
+            measurementService.addMeasuredConditionCopyToAllActiveGrows(condDto);
         }
     }
 }


### PR DESCRIPTION
Uses the right method to duplicate the measurements to all active grow